### PR TITLE
Issue #6 : Add Namespace and Probes Configuration to Kubernetes Manifests

### DIFF
--- a/demo-extended/Chart.yaml
+++ b/demo-extended/Chart.yaml
@@ -1,5 +1,5 @@
-apiVersion: v1
-name: custom-template
+apiVersion: v2
+name: extended-demo
 description: Demo chart with more properties to chose from
 
 type: application

--- a/demo-extended/Chart.yaml
+++ b/demo-extended/Chart.yaml
@@ -1,5 +1,5 @@
-apiVersion: v2
-name: extended-demo
+apiVersion: v1
+name: custom-template
 description: Demo chart with more properties to chose from
 
 type: application

--- a/demo-extended/templates/deployment.yaml
+++ b/demo-extended/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
   labels:
     app: {{ .Values.name }}
 spec:

--- a/demo-extended/templates/deployment.yaml
+++ b/demo-extended/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: {{ .Values.name }}
 spec:
-  replicas: {{ (.Values.scaling).replicas | default 1 }}
+  replicas: {{ .Values.scaling.replicas }}
   selector:
     matchLabels:
       app: {{ .Values.name }}
@@ -18,32 +18,48 @@ spec:
       containers:
         - name: {{ .Values.name }}
           image: "{{ .Values.general.image }}:{{ .Values.general.version }}"
-          {{- if ((.Values.networking).expose) }}
+          
+          {{- if .Values.networking.expose }}
           ports:
             - name: http
-              containerPort: {{ .Values.networking.port | default 80 }}
+              containerPort: {{ .Values.networking.port }}
               protocol: TCP
           {{- end }}
+          
           env:
-          {{- if ((.Values.general).environment) }}
-          {{- range $key, $value := (.Values.general).environment }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
+          {{- if .Values.general.environment }}
+          {{- toYaml .Values.general.environment | indent 12 }}
           {{- end }}
-          {{- end }}
-          {{- if or ((.Values.scaling).resources).memory ((.Values.scaling).resources).cpu }}
+
           resources:
-            {{- if ((.Values.scaling).resources).memory }}
+            {{- if .Values.scaling.resources.memory }}
             limits:
-              memory: {{ ((.Values.scaling).resources).memory }}Gi
+              memory: "{{ .Values.scaling.resources.memory }}Gi"
             {{- end }}
-            {{- if or ((.Values.scaling).resources).memory ((.Values.scaling).resources).cpu }}
+            {{- if .Values.scaling.resources.cpu }}
             requests:
-              {{- if ((.Values.scaling).resources).cpu }}
-              cpu: {{ ((.Values.scaling).resources).cpu }}
-              {{- end }}
-              {{- if ((.Values.scaling).resources).memory }}
-              memory: {{ ((.Values.scaling).resources).memory }}Gi
-              {{- end }}
+              cpu: "{{ .Values.scaling.resources.cpu }}"
             {{- end }}
-          {{- end }}
+
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probes.readiness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probes.liveness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+
+          startupProbe:
+            httpGet:
+              path: {{ .Values.probes.startup.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}

--- a/demo-extended/templates/deployment.yaml
+++ b/demo-extended/templates/deployment.yaml
@@ -41,6 +41,7 @@ spec:
               cpu: "{{ .Values.scaling.resources.cpu }}"
             {{- end }}
 
+          {{- if .Values.probes.enabled }}
           readinessProbe:
             httpGet:
               path: {{ .Values.probes.readiness.path }}
@@ -63,3 +64,4 @@ spec:
             initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
             periodSeconds: {{ .Values.probes.startup.periodSeconds }}
             failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+          {{- end }}

--- a/demo-extended/templates/deployment.yaml
+++ b/demo-extended/templates/deployment.yaml
@@ -18,23 +18,18 @@ spec:
       containers:
         - name: {{ .Values.name }}
           image: "{{ .Values.general.image }}:{{ .Values.general.version }}"
-          
           {{- if .Values.networking.expose }}
           ports:
             - name: http
               containerPort: {{ .Values.networking.port }}
               protocol: TCP
           {{- end }}
-          
           env:
-          {{- if ((.Values.general).environment) }}
-          {{- range $key, $value := (.Values.general).environment }}
+          {{- range $key, $value := .Values.general.environment }}
             - name: {{ $key }}
               value: {{ $value | quote }}
           {{- end }}
-          {{- end }}
           {{- if or ((.Values.scaling).resources).memory ((.Values.scaling).resources).cpu }}
-
           resources:
             {{- if .Values.scaling.resources.memory }}
             limits:
@@ -44,28 +39,29 @@ spec:
             requests:
               cpu: "{{ .Values.scaling.resources.cpu }}"
             {{- end }}
-
+          {{- end }}
           {{- if .Values.probes.enabled }}
+          {{- with .Values.probes }}
           readinessProbe:
             httpGet:
-              path: {{ .Values.probes.readiness.path }}
+              path: {{ .readiness.path }}
               port: http
-            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
-            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
-            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
-
+            initialDelaySeconds: {{ .readiness.initialDelaySeconds }}
+            periodSeconds: {{ .readiness.periodSeconds }}
+            failureThreshold: {{ .readiness.failureThreshold }}
           livenessProbe:
             httpGet:
-              path: {{ .Values.probes.liveness.path }}
+              path: {{ .liveness.path }}
               port: http
-            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
-            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
-
+            initialDelaySeconds: {{ .liveness.initialDelaySeconds }}
+            periodSeconds: {{ .liveness.periodSeconds }}
+            failureThreshold: {{ .liveness.failureThreshold }}
           startupProbe:
             httpGet:
-              path: {{ .Values.probes.startup.path }}
+              path: {{ .startup.path }}
               port: http
-            initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
-            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
-            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+            initialDelaySeconds: {{ .startup.initialDelaySeconds }}
+            periodSeconds: {{ .startup.periodSeconds }}
+            failureThreshold: {{ .startup.failureThreshold }}
+          {{- end }}
           {{- end }}

--- a/demo-extended/templates/deployment.yaml
+++ b/demo-extended/templates/deployment.yaml
@@ -27,9 +27,13 @@ spec:
           {{- end }}
           
           env:
-          {{- if .Values.general.environment }}
-          {{- toYaml .Values.general.environment | indent 12 }}
+          {{- if ((.Values.general).environment) }}
+          {{- range $key, $value := (.Values.general).environment }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
           {{- end }}
+          {{- end }}
+          {{- if or ((.Values.scaling).resources).memory ((.Values.scaling).resources).cpu }}
 
           resources:
             {{- if .Values.scaling.resources.memory }}

--- a/demo-extended/templates/services.yaml
+++ b/demo-extended/templates/services.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
   labels:
     app: {{ .Values.name }}
 spec:

--- a/demo-extended/values.schema.json
+++ b/demo-extended/values.schema.json
@@ -82,70 +82,86 @@
     "probes": {
       "type": "object",
       "title": "Probes",
+      "description": "Configuration for container probes",
       "properties": {
         "startup": {
           "title": "Startup Probe",
           "type": "object",
+          "description": "Configuration for the startup probe",
           "properties": {
             "path": {
               "title": "Path for probe",
-              "type": "string"
+              "type": "string",
+              "description": "The endpoint to probe for startup readiness"
             },
             "initialDelaySeconds": {
               "title": "Initial Delay Seconds",
-              "type": "integer"
+              "type": "integer",
+              "description": "The number of seconds to wait before performing the first probe"
             },
             "periodSeconds": {
               "title": "Period Seconds",
-              "type": "integer"
+              "type": "integer",
+              "description": "The number of seconds between each probe"
             },
             "failureThreshold": {
               "title": "Failure Threshold",
-              "type": "integer"
+              "type": "integer",
+              "description": "The number of consecutive failures required to consider the probe as failed"
             }
           }
         },
         "liveness": {
           "title": "Liveness Probe",
           "type": "object",
+          "description": "Configuration for the liveness probe",
           "properties": {
             "path": {
               "title": "Path for probe",
-              "type": "string"
+              "type": "string",
+              "description": "The endpoint to probe for liveness"
             },
             "initialDelaySeconds": {
               "title": "Initial Delay Seconds",
-              "type": "integer"
+              "type": "integer",
+              "description": "The number of seconds to wait before performing the first probe"
             },
             "periodSeconds": {
               "title": "Period Seconds",
-              "type": "integer"
+              "type": "integer",
+              "description": "The number of seconds between each probe"
             },
             "failureThreshold": {
               "title": "Failure Threshold",
-              "type": "integer"
+              "type": "integer",
+              "description": "The number of consecutive failures required to consider the probe as failed"
             }
           }
         },
         "readiness": {
           "title": "Readiness Probe",
           "type": "object",
+          "description": "Configuration for the readiness probe",
           "properties": {
             "path": {
               "title": "Path for probe",
-              "type": "string"
+              "type": "string",
+              "description": "The endpoint to probe for readiness"
             },
             "initialDelaySeconds": {
               "title": "Initial Delay Seconds",
-              "type": "integer"
+              "type": "integer",
+              "description": "The number of seconds to wait before performing the first probe"
             },
             "periodSeconds": {
               "title": "Period Seconds",
-              "type": "integer"
+              "type": "integer",
+              "description": "The number of seconds between each probe"
             },
             "failureThreshold": {
               "title": "Failure Threshold",
-              "type": "integer"
+              "type": "integer",
+              "description": "The number of consecutive failures required to consider the probe as failed"
             }
           }
         }

--- a/demo-extended/values.schema.json
+++ b/demo-extended/values.schema.json
@@ -87,7 +87,7 @@
         "enabled": {
           "title": "Enabled",
           "type": "boolean",
-          "default": true,
+          "default": false,
           "description": "Toggle to enable or disable all probes"
         },
         "startup": {

--- a/demo-extended/values.schema.json
+++ b/demo-extended/values.schema.json
@@ -5,6 +5,11 @@
       "title": "Name",
       "description": "Application name"
     },
+    "namespace": {
+      "type": "string",
+      "title": "Namespace",
+      "description": "Namespace for Application"
+    },  
     "general": {
       "type": "object",
       "title": "General",

--- a/demo-extended/values.schema.json
+++ b/demo-extended/values.schema.json
@@ -84,6 +84,12 @@
       "title": "Probes",
       "description": "Configuration for container probes",
       "properties": {
+        "enabled": {
+          "title": "Enabled",
+          "type": "boolean",
+          "default": true,
+          "description": "Toggle to enable or disable all probes"
+        },
         "startup": {
           "title": "Startup Probe",
           "type": "object",
@@ -108,12 +114,6 @@
               "title": "Failure Threshold",
               "type": "integer",
               "description": "The number of consecutive failures required to consider the probe as failed"
-            },
-            "enabled": {
-              "title": "Enabled",
-              "type": "boolean",
-              "default": true,
-              "description": "Toggle to enable or disable the startup probe"
             }
           }
         },
@@ -141,12 +141,6 @@
               "title": "Failure Threshold",
               "type": "integer",
               "description": "The number of consecutive failures required to consider the probe as failed"
-            },
-            "enabled": {
-              "title": "Enabled",
-              "type": "boolean",
-              "default": true,
-              "description": "Toggle to enable or disable the liveness probe"
             }
           }
         },
@@ -174,17 +168,12 @@
               "title": "Failure Threshold",
               "type": "integer",
               "description": "The number of consecutive failures required to consider the probe as failed"
-            },
-            "enabled": {
-              "title": "Enabled",
-              "type": "boolean",
-              "default": true,
-              "description": "Toggle to enable or disable the readiness probe"
             }
           }
         }
       },
       "order": [
+        "enabled",
         "startup",
         "liveness",
         "readiness"

--- a/demo-extended/values.schema.json
+++ b/demo-extended/values.schema.json
@@ -120,6 +120,10 @@
             "periodSeconds": {
               "title": "Period Seconds",
               "type": "integer"
+            },
+            "failureThreshold": {
+              "title": "Failure Threshold",
+              "type": "integer"
             }
           }
         },

--- a/demo-extended/values.schema.json
+++ b/demo-extended/values.schema.json
@@ -230,5 +230,7 @@
     "scaling",
     "probes",
     "networking"
-  ]
+  ],
+  "title": "Values",
+  "type": "object"
 }

--- a/demo-extended/values.schema.json
+++ b/demo-extended/values.schema.json
@@ -108,6 +108,12 @@
               "title": "Failure Threshold",
               "type": "integer",
               "description": "The number of consecutive failures required to consider the probe as failed"
+            },
+            "enabled": {
+              "title": "Enabled",
+              "type": "boolean",
+              "default": true,
+              "description": "Toggle to enable or disable the startup probe"
             }
           }
         },
@@ -135,6 +141,12 @@
               "title": "Failure Threshold",
               "type": "integer",
               "description": "The number of consecutive failures required to consider the probe as failed"
+            },
+            "enabled": {
+              "title": "Enabled",
+              "type": "boolean",
+              "default": true,
+              "description": "Toggle to enable or disable the liveness probe"
             }
           }
         },
@@ -162,6 +174,12 @@
               "title": "Failure Threshold",
               "type": "integer",
               "description": "The number of consecutive failures required to consider the probe as failed"
+            },
+            "enabled": {
+              "title": "Enabled",
+              "type": "boolean",
+              "default": true,
+              "description": "Toggle to enable or disable the readiness probe"
             }
           }
         }

--- a/demo-extended/values.schema.json
+++ b/demo-extended/values.schema.json
@@ -230,7 +230,5 @@
     "scaling",
     "probes",
     "networking"
-  ],
-  "title": "Values",
-  "type": "object"
+  ]
 }

--- a/demo-extended/values.schema.json
+++ b/demo-extended/values.schema.json
@@ -1,6 +1,4 @@
 {
-  "title": "Values",
-  "type": "object",
   "properties": {
     "name": {
       "type": "string",
@@ -63,8 +61,8 @@
             },
             "memory": {
               "title": "Memory",
-              "type": "integer",
-              "description": "Measured in Gi"
+              "description": "Measured in Gi",
+              "type": "integer"
             }
           },
           "order": [
@@ -89,7 +87,7 @@
         "enabled": {
           "title": "Enabled",
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "Toggle to enable or disable all probes"
         },
         "startup": {
@@ -117,13 +115,7 @@
               "type": "integer",
               "description": "The number of consecutive failures required to consider the probe as failed"
             }
-          },
-          "order": [
-            "path",
-            "initialDelaySeconds",
-            "periodSeconds",
-            "failureThreshold"
-          ]
+          }
         },
         "liveness": {
           "title": "Liveness Probe",
@@ -150,13 +142,7 @@
               "type": "integer",
               "description": "The number of consecutive failures required to consider the probe as failed"
             }
-          },
-          "order": [
-            "path",
-            "initialDelaySeconds",
-            "periodSeconds",
-            "failureThreshold"
-          ]
+          }
         },
         "readiness": {
           "title": "Readiness Probe",
@@ -183,13 +169,7 @@
               "type": "integer",
               "description": "The number of consecutive failures required to consider the probe as failed"
             }
-          },
-          "order": [
-            "path",
-            "initialDelaySeconds",
-            "periodSeconds",
-            "failureThreshold"
-          ]
+          }
         }
       },
       "order": [
@@ -230,5 +210,7 @@
     "scaling",
     "probes",
     "networking"
-  ]
+  ],
+  "title": "Values",
+  "type": "object"
 }

--- a/demo-extended/values.schema.json
+++ b/demo-extended/values.schema.json
@@ -1,178 +1,162 @@
 {
+  "title": "Values",
+  "type": "object",
   "properties": {
     "name": {
-      "type": "string",
-      "title": "Name",
-      "description": "Application name"
+      "description": "Application name",
+      "type": "string"
     },
     "namespace": {
-      "type": "string",
-      "title": "Namespace",
-      "description": "Namespace for Application"
+      "description": "Kubernetes namespace",
+      "type": "string"
     },
     "general": {
+      "description": "General configuration",
       "type": "object",
-      "title": "General",
       "properties": {
         "image": {
-          "title": "App image",
-          "type": "string",
-          "description": "Application image"
+          "description": "Container image",
+          "type": "string"
         },
         "version": {
-          "title": "Image version",
-          "type": "string",
-          "description": "Image tag you want to deploy"
+          "description": "Container image version",
+          "type": "string"
         },
         "environment": {
-          "title": "Environment variables",
+          "description": "Environment variables",
           "type": "object",
-          "description": "Set environment variables"
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       },
       "required": [
         "image",
         "version"
-      ],
-      "order": [
-        "image",
-        "version",
-        "environment"
       ]
     },
     "scaling": {
+      "description": "Scaling configuration",
       "type": "object",
-      "title": "Scaling",
       "properties": {
         "replicas": {
-          "title": "Replicas",
-          "type": "integer",
-          "description": "Number of instances you want to deploy",
-          "minimum": 0
+          "description": "Number of replicas",
+          "type": "integer"
         },
         "resources": {
+          "description": "Resource limits and requests",
           "type": "object",
-          "title": "Resources",
           "properties": {
             "cpu": {
-              "title": "CPUs",
-              "type": "integer",
-              "description": "Number of CPUs your applications needs"
+              "description": "CPU resource request",
+              "type": "string"
             },
             "memory": {
-              "title": "Memory",
-              "description": "Measured in Gi",
-              "type": "integer"
+              "description": "Memory resource limit",
+              "type": "string"
             }
           },
-          "order": [
-            "cpu",
-            "memory"
-          ]
+          "additionalProperties": false
         }
       },
       "required": [
         "replicas"
-      ],
-      "order": [
-        "replicas",
-        "resources"
       ]
     },
     "probes": {
+      "description": "Probe configuration",
       "type": "object",
-      "title": "Probes",
-      "description": "Configuration for container probes",
       "properties": {
         "enabled": {
-          "title": "Enabled",
-          "type": "boolean",
-          "default": true,
-          "description": "Toggle to enable or disable all probes"
+          "description": "Enable probes",
+          "type": "boolean"
         },
         "startup": {
-          "title": "Startup Probe",
+          "description": "Startup probe configuration",
           "type": "object",
-          "description": "Configuration for the startup probe",
           "properties": {
             "path": {
-              "title": "Path for probe",
-              "type": "string",
-              "description": "The endpoint to probe for startup readiness"
+              "description": "HTTP path for probe",
+              "type": "string"
             },
             "initialDelaySeconds": {
-              "title": "Initial Delay Seconds",
-              "type": "integer",
-              "description": "The number of seconds to wait before performing the first probe"
+              "description": "Initial delay for probe",
+              "type": "integer"
             },
             "periodSeconds": {
-              "title": "Period Seconds",
-              "type": "integer",
-              "description": "The number of seconds between each probe"
+              "description": "Period for probe",
+              "type": "integer"
             },
             "failureThreshold": {
-              "title": "Failure Threshold",
-              "type": "integer",
-              "description": "The number of consecutive failures required to consider the probe as failed"
+              "description": "Failure threshold for probe",
+              "type": "integer"
             }
-          }
+          },
+          "required": [
+            "path",
+            "initialDelaySeconds",
+            "periodSeconds",
+            "failureThreshold"
+          ]
         },
         "liveness": {
-          "title": "Liveness Probe",
+          "description": "Liveness probe configuration",
           "type": "object",
-          "description": "Configuration for the liveness probe",
           "properties": {
             "path": {
-              "title": "Path for probe",
-              "type": "string",
-              "description": "The endpoint to probe for liveness"
+              "description": "HTTP path for probe",
+              "type": "string"
             },
             "initialDelaySeconds": {
-              "title": "Initial Delay Seconds",
-              "type": "integer",
-              "description": "The number of seconds to wait before performing the first probe"
+              "description": "Initial delay for probe",
+              "type": "integer"
             },
             "periodSeconds": {
-              "title": "Period Seconds",
-              "type": "integer",
-              "description": "The number of seconds between each probe"
+              "description": "Period for probe",
+              "type": "integer"
             },
             "failureThreshold": {
-              "title": "Failure Threshold",
-              "type": "integer",
-              "description": "The number of consecutive failures required to consider the probe as failed"
+              "description": "Failure threshold for probe",
+              "type": "integer"
             }
-          }
+          },
+          "required": [
+            "path",
+            "initialDelaySeconds",
+            "periodSeconds",
+            "failureThreshold"
+          ]
         },
         "readiness": {
-          "title": "Readiness Probe",
+          "description": "Readiness probe configuration",
           "type": "object",
-          "description": "Configuration for the readiness probe",
           "properties": {
             "path": {
-              "title": "Path for probe",
-              "type": "string",
-              "description": "The endpoint to probe for readiness"
+              "description": "HTTP path for probe",
+              "type": "string"
             },
             "initialDelaySeconds": {
-              "title": "Initial Delay Seconds",
-              "type": "integer",
-              "description": "The number of seconds to wait before performing the first probe"
+              "description": "Initial delay for probe",
+              "type": "integer"
             },
             "periodSeconds": {
-              "title": "Period Seconds",
-              "type": "integer",
-              "description": "The number of seconds between each probe"
+              "description": "Period for probe",
+              "type": "integer"
             },
             "failureThreshold": {
-              "title": "Failure Threshold",
-              "type": "integer",
-              "description": "The number of consecutive failures required to consider the probe as failed"
+              "description": "Failure threshold for probe",
+              "type": "integer"
             }
-          }
+          },
+          "required": [
+            "path",
+            "initialDelaySeconds",
+            "periodSeconds",
+            "failureThreshold"
+          ]
         }
       },
-      "order": [
+      "required": [
         "enabled",
         "startup",
         "liveness",
@@ -180,29 +164,24 @@
       ]
     },
     "networking": {
+      "description": "Networking configuration",
       "type": "object",
-      "title": "Networking",
       "properties": {
         "expose": {
-          "title": "Expose",
-          "type": "boolean",
-          "description": "Create a Service for your application"
+          "description": "Expose container port",
+          "type": "boolean"
         },
         "port": {
-          "title": "Port",
-          "type": "integer",
-          "description": "Port to expose for your application"
+          "description": "Container port",
+          "type": "integer"
         }
       },
-      "order": [
+      "required": [
         "expose",
         "port"
       ]
     }
   },
-  "required": [
-    "name"
-  ],
   "order": [
     "name",
     "namespace",
@@ -211,6 +190,12 @@
     "probes",
     "networking"
   ],
-  "title": "Values",
-  "type": "object"
+  "required": [
+    "name",
+    "namespace",
+    "general",
+    "scaling",
+    "probes",
+    "networking"
+  ]
 }

--- a/demo-extended/values.schema.json
+++ b/demo-extended/values.schema.json
@@ -115,7 +115,13 @@
               "type": "integer",
               "description": "The number of consecutive failures required to consider the probe as failed"
             }
-          }
+          },
+          "order": [
+            "path",
+            "initialDelaySeconds",
+            "periodSeconds",
+            "failureThreshold"
+          ]
         },
         "liveness": {
           "title": "Liveness Probe",
@@ -142,7 +148,13 @@
               "type": "integer",
               "description": "The number of consecutive failures required to consider the probe as failed"
             }
-          }
+          },
+          "order": [
+            "path",
+            "initialDelaySeconds",
+            "periodSeconds",
+            "failureThreshold"
+          ]
         },
         "readiness": {
           "title": "Readiness Probe",
@@ -169,7 +181,13 @@
               "type": "integer",
               "description": "The number of consecutive failures required to consider the probe as failed"
             }
-          }
+          },
+          "order": [
+            "path",
+            "initialDelaySeconds",
+            "periodSeconds",
+            "failureThreshold"
+          ]
         }
       },
       "order": [

--- a/demo-extended/values.schema.json
+++ b/demo-extended/values.schema.json
@@ -1,4 +1,6 @@
 {
+  "title": "Values",
+  "type": "object",
   "properties": {
     "name": {
       "type": "string",
@@ -61,8 +63,8 @@
             },
             "memory": {
               "title": "Memory",
-              "description": "Measured in Gi",
-              "type": "integer"
+              "type": "integer",
+              "description": "Measured in Gi"
             }
           },
           "order": [
@@ -228,7 +230,5 @@
     "scaling",
     "probes",
     "networking"
-  ],
-  "title": "Values",
-  "type": "object"
+  ]
 }

--- a/demo-extended/values.schema.json
+++ b/demo-extended/values.schema.json
@@ -9,7 +9,7 @@
       "type": "string",
       "title": "Namespace",
       "description": "Namespace for Application"
-    },  
+    },
     "general": {
       "type": "object",
       "title": "General",
@@ -79,6 +79,79 @@
         "resources"
       ]
     },
+    "probes": {
+      "type": "object",
+      "title": "Probes",
+      "properties": {
+        "startup": {
+          "title": "Startup Probe",
+          "type": "object",
+          "properties": {
+            "path": {
+              "title": "Path for probe",
+              "type": "string"
+            },
+            "initialDelaySeconds": {
+              "title": "Initial Delay Seconds",
+              "type": "integer"
+            },
+            "periodSeconds": {
+              "title": "Period Seconds",
+              "type": "integer"
+            },
+            "failureThreshold": {
+              "title": "Failure Threshold",
+              "type": "integer"
+            }
+          }
+        },
+        "liveness": {
+          "title": "Liveness Probe",
+          "type": "object",
+          "properties": {
+            "path": {
+              "title": "Path for probe",
+              "type": "string"
+            },
+            "initialDelaySeconds": {
+              "title": "Initial Delay Seconds",
+              "type": "integer"
+            },
+            "periodSeconds": {
+              "title": "Period Seconds",
+              "type": "integer"
+            }
+          }
+        },
+        "readiness": {
+          "title": "Readiness Probe",
+          "type": "object",
+          "properties": {
+            "path": {
+              "title": "Path for probe",
+              "type": "string"
+            },
+            "initialDelaySeconds": {
+              "title": "Initial Delay Seconds",
+              "type": "integer"
+            },
+            "periodSeconds": {
+              "title": "Period Seconds",
+              "type": "integer"
+            },
+            "failureThreshold": {
+              "title": "Failure Threshold",
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "order": [
+        "startup",
+        "liveness",
+        "readiness"
+      ]
+    },
     "networking": {
       "type": "object",
       "title": "Networking",
@@ -105,8 +178,10 @@
   ],
   "order": [
     "name",
+    "namespace",
     "general",
     "scaling",
+    "probes",
     "networking"
   ],
   "title": "Values",

--- a/demo-extended/values.yaml
+++ b/demo-extended/values.yaml
@@ -1,5 +1,5 @@
 name: my-app
-
+namespace: default
 general:
   image: nginx
   version: 1.14.2

--- a/demo-extended/values.yaml
+++ b/demo-extended/values.yaml
@@ -8,6 +8,25 @@ general:
 
 scaling:
   replicas: 3
+  resources:
+    cpu: 1
+    memory: 512
+
+probes:
+  startup:
+    path: "/"
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    failureThreshold: 3
+  liveness:
+    path: "/"
+    initialDelaySeconds: 10
+    periodSeconds: 20
+  readiness:
+    path: "/"
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    failureThreshold: 3
 
 networking:
   expose: true

--- a/demo-extended/values.yaml
+++ b/demo-extended/values.yaml
@@ -18,16 +18,19 @@ probes:
     initialDelaySeconds: 5
     periodSeconds: 10
     failureThreshold: 3
+    enabled: false
   liveness:
     path: "/"
     initialDelaySeconds: 10
     periodSeconds: 20
     failureThreshold: 3
+    enabled: true
   readiness:
     path: "/"
     initialDelaySeconds: 5
     periodSeconds: 10
     failureThreshold: 3
+    enabled: true
 
 networking:
   expose: true

--- a/demo-extended/values.yaml
+++ b/demo-extended/values.yaml
@@ -5,13 +5,11 @@ general:
   version: 1.14.2
   environment:
     ENVIRONMENT: production
-
 scaling:
   replicas: 3
   resources:
     cpu: 1
     memory: 512
-
 probes:
   enabled: true
   startup:
@@ -29,7 +27,6 @@ probes:
     initialDelaySeconds: 5
     periodSeconds: 10
     failureThreshold: 3
-
 networking:
   expose: true
   port: 8080

--- a/demo-extended/values.yaml
+++ b/demo-extended/values.yaml
@@ -13,7 +13,7 @@ scaling:
     memory: 512
 
 probes:
-  enabled: false
+  enabled: true
   startup:
     path: "/"
     initialDelaySeconds: 5

--- a/demo-extended/values.yaml
+++ b/demo-extended/values.yaml
@@ -13,7 +13,7 @@ scaling:
     memory: 512
 
 probes:
-  enabled: true
+  enabled: false
   startup:
     path: "/"
     initialDelaySeconds: 5

--- a/demo-extended/values.yaml
+++ b/demo-extended/values.yaml
@@ -13,24 +13,22 @@ scaling:
     memory: 512
 
 probes:
+  enabled: true
   startup:
     path: "/"
     initialDelaySeconds: 5
     periodSeconds: 10
     failureThreshold: 3
-    enabled: false
   liveness:
     path: "/"
     initialDelaySeconds: 10
     periodSeconds: 20
     failureThreshold: 3
-    enabled: true
   readiness:
     path: "/"
     initialDelaySeconds: 5
     periodSeconds: 10
     failureThreshold: 3
-    enabled: true
 
 networking:
   expose: true

--- a/demo-extended/values.yaml
+++ b/demo-extended/values.yaml
@@ -22,6 +22,7 @@ probes:
     path: "/"
     initialDelaySeconds: 10
     periodSeconds: 20
+    failureThreshold: 3
   readiness:
     path: "/"
     initialDelaySeconds: 5


### PR DESCRIPTION
Hi @petar-cvit @KaradzaJuraj ,

This pull request focuses on the addition of new fields within various files, namely "deployment.yaml", "services.yaml", "values.schema.json", and "values.yaml". Here's a summary of the changes made:

 1.   In "demo-extended/templates/deployment.yaml", I have introduced YAML code for Namespace and Probes (specifically, readinessProbe, livenessProbe, and startupProbe). The default values for these fields are retrieved from "values.yaml".

 2.   Within "demo-extended/templates/services.yaml", I have incorporated YAML code for Namespace. Similar to the deployment template, the default values for these fields are sourced from "values.yaml".

 3.   In "demo-extended/values.schema.json", I have extended the JSON schema to include the Namespace field below Name, which falls under the metadata of deployment.yml. Additionally, I have structured a separate, expandable section for Probes, allowing users to conveniently review and customize each probe as needed.

 4.   Within "demo-extended/values.yaml", default values have been provided for the newly added fields in the branch, along with resources (CPU and memory), which were previously declared but lacked default values.

Please Review the PR and feel free to contact me if any improvement required from my end 👍 ,

Thanks & Regards,
Rohan Rustagi